### PR TITLE
Implement MVCC Async Store using local rocksdb and distributedlog stream

### DIFF
--- a/distributedlog-build-tools/src/main/resources/distributedlog/findbugsExclude.xml
+++ b/distributedlog-build-tools/src/main/resources/distributedlog/findbugsExclude.xml
@@ -182,4 +182,10 @@
     <Class name="org.apache.distributedlog.messaging.RRMultiWriter" />
     <Bug pattern="EI_EXPOSE_REP2" />
   </Match>
+  <!-- state-store -->
+  <Match>
+    <!-- it is safe to store external bytes reference here. //-->
+    <Class name="org.apache.distributedlog.statestore.impl.mvcc.op.proto.ProtoPutOpImpl" />
+    <Bug pattern="EI_EXPOSE_REP" />
+  </Match>
 </FindBugsFilter>

--- a/distributedlog-common/pom.xml
+++ b/distributedlog-common/pom.xml
@@ -63,6 +63,11 @@
       <version>${commons-lang.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>${commons-codec.version}</version>

--- a/distributedlog-common/src/main/java/org/apache/distributedlog/common/coder/ByteArrayCoder.java
+++ b/distributedlog-common/src/main/java/org/apache/distributedlog/common/coder/ByteArrayCoder.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.distributedlog.common.coder;
+
+import io.netty.buffer.ByteBuf;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.distributedlog.common.util.ByteBufUtils;
+
+/**
+ * A byte array {@link Coder<byte[]>}.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ByteArrayCoder implements Coder<byte[]> {
+
+    public static ByteArrayCoder of() {
+        return INSTANCE;
+    }
+
+    private static final ByteArrayCoder INSTANCE = new ByteArrayCoder();
+
+    @Override
+    public byte[] encode(byte[] value) {
+        return value;
+    }
+
+    @Override
+    public byte[] decode(ByteBuf data) {
+        return ByteBufUtils.getArray(data);
+    }
+}

--- a/distributedlog-common/src/main/java/org/apache/distributedlog/common/concurrent/AsyncSemaphore.java
+++ b/distributedlog-common/src/main/java/org/apache/distributedlog/common/concurrent/AsyncSemaphore.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Supplier;
-import javax.annotation.concurrent.GuardedBy;
 import org.apache.distributedlog.common.util.Permit;
 
 /**
@@ -54,11 +53,8 @@ public class AsyncSemaphore {
         }
     };
 
-    @GuardedBy("this")
     private Optional<Throwable> closed = Optional.empty();
-    @GuardedBy("this")
     private final LinkedList<CompletableFuture<Permit>> waitq;
-    @GuardedBy("this")
     private int availablePermits;
 
     public AsyncSemaphore(int initialPermits,

--- a/distributedlog-core/src/main/java/org/apache/bookkeeper/client/LedgerReader.java
+++ b/distributedlog-core/src/main/java/org/apache/bookkeeper/client/LedgerReader.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.bookkeeper.client.DistributionSchedule.WriteSet;
 import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieClient;
 import org.apache.bookkeeper.proto.BookkeeperInternalCallbacks.GenericCallback;
@@ -86,7 +87,7 @@ public class LedgerReader {
 
     public void readEntriesFromAllBookies(final LedgerHandle lh, long eid,
                                           final GenericCallback<Set<ReadResult<ByteBuf>>> callback) {
-        List<Integer> writeSet = lh.distributionSchedule.getWriteSet(eid);
+        WriteSet writeSet = lh.distributionSchedule.getWriteSet(eid);
         final AtomicInteger numBookies = new AtomicInteger(writeSet.size());
         final Set<ReadResult<ByteBuf>> readResults = new HashSet<>();
         ReadEntryCallback readEntryCallback = new ReadEntryCallback() {
@@ -118,7 +119,8 @@ public class LedgerReader {
         };
 
         ArrayList<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsemble(eid);
-        for (Integer idx : writeSet) {
+        for (int i = 0; i < writeSet.size(); i++) {
+            int idx = writeSet.get(i);
             bookieClient.readEntry(ensemble.get(idx), lh.getId(), eid, readEntryCallback, ensemble.get(idx));
         }
     }
@@ -181,7 +183,7 @@ public class LedgerReader {
 
     public void readLacs(final LedgerHandle lh, long eid,
                          final GenericCallback<Set<ReadResult<Long>>> callback) {
-        List<Integer> writeSet = lh.distributionSchedule.getWriteSet(eid);
+        WriteSet writeSet = lh.distributionSchedule.getWriteSet(eid);
         final AtomicInteger numBookies = new AtomicInteger(writeSet.size());
         final Set<ReadResult<Long>> readResults = new HashSet<ReadResult<Long>>();
         ReadEntryCallback readEntryCallback = (rc, lid, eid1, buffer, ctx) -> {
@@ -204,7 +206,8 @@ public class LedgerReader {
         };
 
         ArrayList<BookieSocketAddress> ensemble = lh.getLedgerMetadata().getEnsemble(eid);
-        for (Integer idx : writeSet) {
+        for (int i = 0; i < writeSet.size(); i++) {
+            int idx = writeSet.get(i);
             bookieClient.readEntry(ensemble.get(idx), lh.getId(), eid, readEntryCallback, ensemble.get(idx));
         }
     }

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/api/StateStoreSpec.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/api/StateStoreSpec.java
@@ -67,11 +67,18 @@ public interface StateStoreSpec {
     Optional<String> stream();
 
     /**
-     * Returns the i/o scheduler used by the state store.
+     * Returns the i/o scheduler used for write operations at the state store.
      *
      * @return the i/o scheduler
      */
-    Optional<ScheduledExecutorService> ioScheduler();
+    Optional<ScheduledExecutorService> writeIOScheduler();
+
+    /**
+     * Returns the i/o scheduler used for read operations at the state store.
+     *
+     * @return the i/o scheduler
+     */
+    Optional<ScheduledExecutorService> readIOScheduler();
 
     /**
      * Returns all the store specific config properties as key/value pairs.

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/api/StateStoreSpec.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/api/StateStoreSpec.java
@@ -20,6 +20,8 @@ package org.apache.distributedlog.statestore.api;
 
 import java.io.File;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
 import org.apache.distributedlog.common.coder.Coder;
 import org.inferred.freebuilder.FreeBuilder;
 
@@ -55,14 +57,21 @@ public interface StateStoreSpec {
      *
      * @return the local directory that is used for storing state locally.
      */
-    File localStateStoreDir();
+    Optional<File> localStateStoreDir();
 
     /**
      * Returns the distributedlog stream name that is used for storing updates durably.
      *
      * @return the stream name.
      */
-    String stream();
+    Optional<String> stream();
+
+    /**
+     * Returns the i/o scheduler used by the state store.
+     *
+     * @return the i/o scheduler
+     */
+    Optional<ScheduledExecutorService> ioScheduler();
 
     /**
      * Returns all the store specific config properties as key/value pairs.

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/api/mvcc/MVCCAsyncStore.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/api/mvcc/MVCCAsyncStore.java
@@ -21,6 +21,7 @@ package org.apache.distributedlog.statestore.api.mvcc;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.Public;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Evolving;
 import org.apache.distributedlog.statestore.api.AsyncStateStore;
+import org.apache.distributedlog.statestore.api.mvcc.op.OpFactory;
 
 /**
  * A mvcc store that supports asynchronous operations.
@@ -34,4 +35,12 @@ public interface MVCCAsyncStore<K, V>
     extends AsyncStateStore,
             MVCCAsyncStoreWriteView<K, V>,
             MVCCAsyncStoreReadView<K, V> {
+
+    /**
+     * Return the operator factory to build operators.
+     *
+     * @return operator factory.
+     */
+    OpFactory<K, V> getOpFactory();
+
 }

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/exceptions/StateStoreClosedException.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/exceptions/StateStoreClosedException.java
@@ -16,32 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.distributedlog.common.coder;
-
-import io.netty.buffer.ByteBuf;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import org.apache.distributedlog.common.util.ByteBufUtils;
+package org.apache.distributedlog.statestore.exceptions;
 
 /**
- * A byte array {@link Coder}.
+ * Exceptions are thrown when a state store is closed.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ByteArrayCoder implements Coder<byte[]> {
+public class StateStoreClosedException extends StateStoreException {
 
-    public static ByteArrayCoder of() {
-        return INSTANCE;
-    }
+    private static final long serialVersionUID = 1L;
 
-    private static final ByteArrayCoder INSTANCE = new ByteArrayCoder();
-
-    @Override
-    public byte[] encode(byte[] value) {
-        return value;
-    }
-
-    @Override
-    public byte[] decode(ByteBuf data) {
-        return ByteBufUtils.getArray(data);
+    public StateStoreClosedException(String storeName) {
+        super("State store " + storeName + " is already closed");
     }
 }

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/MVCCAsyncBytesStoreImpl.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/MVCCAsyncBytesStoreImpl.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.distributedlog.statestore.impl.mvcc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.distributedlog.statestore.impl.mvcc.MVCCUtils.NOP_CMD;
+import static org.apache.distributedlog.statestore.impl.mvcc.MVCCUtils.newCommand;
+import static org.apache.distributedlog.statestore.impl.mvcc.MVCCUtils.toCommand;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.concurrent.FutureEventListener;
+import org.apache.bookkeeper.common.concurrent.FutureUtils;
+import org.apache.distributedlog.DLSN;
+import org.apache.distributedlog.LogRecord;
+import org.apache.distributedlog.LogRecordWithDLSN;
+import org.apache.distributedlog.api.AsyncLogReader;
+import org.apache.distributedlog.api.AsyncLogWriter;
+import org.apache.distributedlog.api.DistributedLogManager;
+import org.apache.distributedlog.api.namespace.Namespace;
+import org.apache.distributedlog.statestore.api.StateStoreSpec;
+import org.apache.distributedlog.statestore.api.mvcc.MVCCAsyncStore;
+import org.apache.distributedlog.statestore.api.mvcc.op.DeleteOp;
+import org.apache.distributedlog.statestore.api.mvcc.op.OpFactory;
+import org.apache.distributedlog.statestore.api.mvcc.op.PutOp;
+import org.apache.distributedlog.statestore.api.mvcc.op.RangeOp;
+import org.apache.distributedlog.statestore.api.mvcc.op.TxnOp;
+import org.apache.distributedlog.statestore.api.mvcc.result.Code;
+import org.apache.distributedlog.statestore.api.mvcc.result.DeleteResult;
+import org.apache.distributedlog.statestore.api.mvcc.result.PutResult;
+import org.apache.distributedlog.statestore.api.mvcc.result.RangeResult;
+import org.apache.distributedlog.statestore.api.mvcc.result.TxnResult;
+import org.apache.distributedlog.statestore.exceptions.InvalidStateStoreException;
+import org.apache.distributedlog.statestore.exceptions.MVCCStoreException;
+import org.apache.distributedlog.statestore.exceptions.StateStoreClosedException;
+import org.apache.distributedlog.statestore.exceptions.StateStoreException;
+import org.apache.distributedlog.statestore.exceptions.StateStoreRuntimeException;
+import org.apache.distributedlog.statestore.impl.mvcc.op.proto.ProtoPutOpImpl;
+import org.apache.distributedlog.statestore.proto.Command;
+import org.apache.distributedlog.util.Utils;
+
+/**
+ * MVCC Async Store Implementation.
+ */
+@Slf4j
+class MVCCAsyncBytesStoreImpl implements MVCCAsyncStore<byte[], byte[]> {
+
+    // parameters
+    private String name = "UNINITIALIZED";
+
+    // local state
+    private final MVCCStoreImpl<byte[], byte[]> localStore;
+    private boolean ownWriteScheduler = false;
+    private boolean ownReadScheduler = false;
+    private ScheduledExecutorService writeIOScheduler;
+    private ScheduledExecutorService readIOScheduler;
+
+    // journal
+    private Namespace logNamespace;
+    private DistributedLogManager logManager;
+    private AsyncLogWriter writer;
+    private long nextRevision;
+
+    // close state
+    private boolean isInitialized = false;
+    private CompletableFuture<Void> closeFuture = null;
+
+    MVCCAsyncBytesStoreImpl(Supplier<MVCCStoreImpl<byte[], byte[]>> storeSupplier,
+                            Supplier<Namespace> namespaceSupplier) {
+        this.localStore = storeSupplier.get();
+        this.logNamespace = namespaceSupplier.get();
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public OpFactory<byte[], byte[]> getOpFactory() {
+        return localStore.getOpFactory();
+    }
+
+    @VisibleForTesting
+    boolean ownWriteScheduler() {
+        return ownWriteScheduler;
+    }
+
+    @VisibleForTesting
+    boolean ownReadScheduler() {
+        return ownReadScheduler;
+    }
+
+    synchronized AsyncLogWriter getWriter() {
+        return writer;
+    }
+
+    private <T> CompletableFuture<T> executeIO(ScheduledExecutorService scheduler,
+                                               Callable<T> callable) {
+        synchronized (this) {
+            if (null != closeFuture) {
+                return FutureUtils.exception(new StateStoreClosedException(name()));
+            }
+        }
+
+        CompletableFuture<T> future = FutureUtils.createFuture();
+        scheduler.submit(() -> {
+            try {
+                T value = callable.call();
+                future.complete(value);
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    private <T> CompletableFuture<T> executeWriteIO(Callable<T> callable) {
+        return executeIO(writeIOScheduler, callable);
+    }
+
+    private <T> CompletableFuture<T> executeReadIO(Callable<T> callable) {
+        return executeIO(readIOScheduler, callable);
+    }
+
+    private CompletableFuture<DLSN> writeCommand(Command command) {
+        if (log.isTraceEnabled()) {
+            log.trace("Writing command {} to mvcc store {}", command, name());
+        }
+        ByteBuf recordBuf;
+        try {
+            recordBuf = MVCCUtils.newLogRecordBuf(command);
+        } catch (StateStoreRuntimeException e) {
+            return FutureUtils.exception(e);
+        }
+        synchronized (this) {
+            long txId = ++nextRevision;
+            return FutureUtils.ensure(
+                writer.write(new LogRecord(txId, recordBuf)),
+                () -> recordBuf.release());
+        }
+    }
+
+    private CompletableFuture<Long> writeCommandReturnTxId(Command command) {
+        ByteBuf recordBuf = MVCCUtils.newLogRecordBuf(command);
+        synchronized (this) {
+            long txId = ++nextRevision;
+            return FutureUtils.ensure(
+                writer.write(new LogRecord(txId, recordBuf))
+                    .thenApply(dlsn -> txId),
+                () -> recordBuf.release());
+        }
+    }
+
+    private void validateStoreSpec(StateStoreSpec spec) {
+        checkArgument(spec.stream().isPresent(), "No log stream is specified for state store " + spec.name());
+    }
+
+    @Override
+    public CompletableFuture<Void> init(StateStoreSpec spec) {
+        try {
+            validateStoreSpec(spec);
+        } catch (IllegalArgumentException e) {
+            log.error("Fail to init state store due to : ", e);
+            return FutureUtils.exception(e);
+        }
+        name = spec.name();
+
+        if (spec.writeIOScheduler().isPresent()) {
+            writeIOScheduler = spec.writeIOScheduler().get();
+            ownWriteScheduler = false;
+        } else {
+            ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("statestore-" + spec.name() + "-write-io-scheduler-%d")
+                .build();
+            writeIOScheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
+            ownWriteScheduler = true;
+        }
+
+        if (spec.readIOScheduler().isPresent()) {
+            readIOScheduler = spec.readIOScheduler().get();
+        } else if (ownWriteScheduler) {
+            readIOScheduler = writeIOScheduler;
+            ownReadScheduler = false;
+        } else {
+            ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("statestore-" + spec.name() + "-read-io-scheduler-%d")
+                .build();
+            readIOScheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
+            ownReadScheduler = true;
+        }
+
+        return initializeLocalStore(spec)
+            .thenComposeAsync(ignored -> initializeJournalWriter(spec), writeIOScheduler)
+            .thenComposeAsync(endDLSN -> {
+                log.info("Successfully write a barrier record for mvcc store {} at {}", name, endDLSN);
+                return replayJournal(endDLSN);
+            }, writeIOScheduler);
+    }
+
+    private CompletableFuture<Void> initializeLocalStore(StateStoreSpec spec) {
+        return executeWriteIO(() -> {
+            log.info("Initializing the local state for mvcc store {}", name());
+            localStore.init(spec);
+            log.info("Initialized the local state for mvcc store {}", name());
+            return null;
+        });
+    }
+
+    private CompletableFuture<DLSN> initializeJournalWriter(StateStoreSpec spec) {
+        synchronized (this) {
+            if (null != closeFuture) {
+                return FutureUtils.exception(new StateStoreClosedException(name()));
+            }
+        }
+
+        try {
+            logManager = logNamespace.openLog(spec.stream().get());
+        } catch (IOException e) {
+            return FutureUtils.exception(e);
+        }
+        return logManager.openAsyncLogWriter().thenComposeAsync(w -> {
+            synchronized (this) {
+                writer = w;
+                nextRevision = writer.getLastTxId();
+                if (nextRevision < 0) {
+                    nextRevision = 0L;
+                }
+                log.info("Initialized the journal writer for mvcc store {} : last revision = {}",
+                    name(), nextRevision);
+            }
+            return writeCommand(NOP_CMD);
+        }, writeIOScheduler);
+    }
+
+    private CompletableFuture<Void> replayJournal(DLSN endDLSN) {
+        return logManager.openAsyncLogReader(DLSN.InitialDLSN)
+            .thenComposeAsync(r -> {
+                CompletableFuture<Void> replayFuture = FutureUtils.createFuture();
+                FutureUtils.ensure(replayFuture, () -> r.asyncClose());
+
+                log.info("Successfully open the journal reader for mvcc store {}", name());
+                replayJournal(r, endDLSN, replayFuture);
+                return replayFuture;
+            }, writeIOScheduler);
+    }
+
+    private void replayJournal(AsyncLogReader reader,
+                               DLSN endDLSN,
+                               CompletableFuture<Void> future) {
+        synchronized (this) {
+            if (null != closeFuture) {
+                FutureUtils.completeExceptionally(future, new StateStoreClosedException(name()));
+                return;
+            }
+        }
+
+        reader.readNext().whenComplete(new FutureEventListener<LogRecordWithDLSN>() {
+            @Override
+            public void onSuccess(LogRecordWithDLSN record) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Received command record {} to replay at mvcc store {}",
+                        record, name());
+                }
+                if (record.getDlsn().compareTo(endDLSN) >= 0) {
+                    log.info("Finished replaying journal for state store {}", name());
+                    markInitialized();
+                    FutureUtils.complete(future, null);
+                    return;
+                }
+
+                try {
+                    applyCommand(record);
+                    // read next record
+                    replayJournal(reader, endDLSN, future);
+                } catch (StateStoreRuntimeException e) {
+                    FutureUtils.completeExceptionally(future, e);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable cause) {
+                FutureUtils.completeExceptionally(future, cause);
+            }
+        });
+    }
+
+    private void applyCommand(LogRecordWithDLSN record) {
+        Command command = newCommand(record.getPayloadBuf());
+        switch (command.getReqCase()) {
+            case NOP_REQ:
+                return;
+            case PUT_REQ:
+                applyPutCommand(record.getTransactionId(), command);
+                return;
+            case DELETE_REQ:
+                applyDeleteCommand(record.getTransactionId(), command);
+                return;
+            case TXN_REQ:
+                applyTxnCommand(record.getTransactionId(), command);
+                return;
+            default:
+                return;
+        }
+    }
+
+    private void applyPutCommand(long revision, Command command) {
+        ProtoPutOpImpl op = ProtoPutOpImpl.newPutOp(revision, command);
+        try {
+            applyPutOp(revision, op, true);
+        } finally {
+            op.recycle();
+        }
+    }
+
+    private void applyPutOp(long revision,
+                            PutOp<byte[], byte[]> op,
+                            boolean ignoreSmallerRevision) {
+        PutResult<byte[], byte[]> result = localStore.put(revision, op);
+        try {
+            if (Code.OK == result.code()
+                || (ignoreSmallerRevision && Code.SMALLER_REVISION == result.code())) {
+                return;
+            }
+            throw new MVCCStoreException(result.code(),
+                "Failed to apply command " + op + " at revision "
+                    + revision + " to the state store " + name());
+        } finally {
+            result.recycle();
+        }
+    }
+
+    private void applyDeleteCommand(long revision, Command command) {
+        throw new UnsupportedOperationException();
+    }
+
+    private void applyTxnCommand(long revision, Command command) {
+        throw new UnsupportedOperationException();
+    }
+
+    private synchronized void markInitialized() {
+        isInitialized = true;
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        CompletableFuture<Void> future;
+        synchronized (this) {
+            if (null != closeFuture) {
+                return closeFuture;
+            }
+            closeFuture = future = FutureUtils.createFuture();
+        }
+
+        FutureUtils.ensure(
+            // close the log streams
+            Utils.closeSequence(
+                writeIOScheduler,
+                true,
+                getWriter(),
+                logManager
+            ),
+            // close the local state store
+            () -> {
+                if (null == writeIOScheduler) {
+                    closeLocalStore();
+                    FutureUtils.complete(future, null);
+                    return;
+                }
+                writeIOScheduler.submit(() -> {
+                    closeLocalStore();
+
+                    if (ownReadScheduler) {
+                        readIOScheduler.shutdown();
+                    }
+                    if (ownWriteScheduler) {
+                        writeIOScheduler.shutdown();
+                    }
+                    FutureUtils.complete(future, null);
+                });
+            }
+        );
+        return future;
+    }
+
+    private void closeLocalStore() {
+        if (null == localStore) {
+            return;
+        }
+        // flush the local store
+        try {
+            localStore.flush();
+        } catch (StateStoreException e) {
+            log.warn("Fail to flush local state store " + name(), e);
+        }
+        // close the local store
+        localStore.close();
+    }
+
+    @Override
+    public CompletableFuture<RangeResult<byte[], byte[]>> range(RangeOp<byte[], byte[]> rangeOp) {
+        synchronized (this) {
+            if (!isInitialized) {
+                return FutureUtils.exception(new InvalidStateStoreException("State store is not initialized yet."));
+            }
+        }
+
+        // consider running read operations in separate I/O threads
+        return executeReadIO(() -> localStore.range(rangeOp));
+    }
+
+    @Override
+    public CompletableFuture<PutResult<byte[], byte[]>> put(PutOp<byte[], byte[]> op) {
+        synchronized (this) {
+            if (!isInitialized) {
+                return FutureUtils.exception(new InvalidStateStoreException("State store is not initialized yet."));
+            }
+        }
+
+        Command command = toCommand(op);
+        return writeCommandReturnTxId(command)
+            .thenApplyAsync(revision -> localStore.put(revision, op), writeIOScheduler);
+    }
+
+    @Override
+    public CompletableFuture<DeleteResult<byte[], byte[]>> delete(DeleteOp<byte[], byte[]> op) {
+        synchronized (this) {
+            if (!isInitialized) {
+                return FutureUtils.exception(new InvalidStateStoreException("State store is not initialized yet."));
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<TxnResult<byte[], byte[]>> txn(TxnOp<byte[], byte[]> op) {
+        synchronized (this) {
+            if (!isInitialized) {
+                return FutureUtils.exception(new InvalidStateStoreException("State store is not initialized yet."));
+            }
+        }
+
+        return null;
+    }
+}

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/MVCCStoreImpl.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/MVCCStoreImpl.java
@@ -346,13 +346,17 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
     }
 
     @Override
-    public synchronized PutResult<K, V> put(PutOp<K, V> op) {
+    public PutResult<K, V> put(PutOp<K, V> op) {
+        return put(op.revision(), op);
+    }
+
+    synchronized PutResult<K, V> put(long revision, PutOp<K, V> op) {
         checkStoreOpen();
 
         WriteBatch batch = new WriteBatch();
         PutResult<K, V> result = null;
         try {
-            result = put(batch, op);
+            result = put(revision, batch, op);
             executeBatch(batch);
             return result;
         } catch (StateStoreRuntimeException e) {
@@ -365,11 +369,10 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
         }
     }
 
-    private PutResult<K, V> put(WriteBatch batch, PutOp<K, V> op) {
+    private PutResult<K, V> put(long revision, WriteBatch batch, PutOp<K, V> op) {
         // parameters
         final K key = op.key();
         final V val = op.value();
-        final long revision = op.revision();
 
         // raw key & value
         final byte[] rawKey = keyCoder.encode(key);
@@ -435,12 +438,20 @@ class MVCCStoreImpl<K, V> extends RocksdbKVStore<K, V> implements MVCCStore<K, V
 
     @Override
     public DeleteResult<K, V> delete(DeleteOp<K, V> op) {
-        return null;
+        return delete(op.revision(), op);
+    }
+
+    synchronized DeleteResult<K, V> delete(long revision, DeleteOp<K, V> op) {
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public TxnResult<K, V> txn(TxnOp<K, V> op) {
-        return null;
+        return txn(op.revision(), op);
+    }
+
+    synchronized TxnResult<K, V> txn(long revision, TxnOp<K, V> op) {
+        throw new UnsupportedOperationException();
     }
 
     //

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/MVCCUtils.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/MVCCUtils.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.distributedlog.statestore.impl.mvcc;
+
+import com.google.common.collect.Lists;
+import com.google.protobuf.UnsafeByteOperations;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.distributedlog.statestore.api.mvcc.op.CompareOp;
+import org.apache.distributedlog.statestore.api.mvcc.op.CompareResult;
+import org.apache.distributedlog.statestore.api.mvcc.op.CompareTarget;
+import org.apache.distributedlog.statestore.api.mvcc.op.DeleteOp;
+import org.apache.distributedlog.statestore.api.mvcc.op.Op;
+import org.apache.distributedlog.statestore.api.mvcc.op.PutOp;
+import org.apache.distributedlog.statestore.api.mvcc.op.TxnOp;
+import org.apache.distributedlog.statestore.proto.Compare;
+import org.apache.distributedlog.statestore.proto.DeleteRequest;
+import org.apache.distributedlog.statestore.proto.PutRequest;
+import org.apache.distributedlog.statestore.proto.RequestOp;
+import org.apache.distributedlog.statestore.proto.TxnRequest;
+
+/**
+ * Utils for mvcc stores.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class MVCCUtils {
+
+    static PutRequest toPutRequest(PutOp<byte[], byte[]> op) {
+        return PutRequest.newBuilder()
+            .setKey(UnsafeByteOperations.unsafeWrap(op.key()))
+            .setValue(UnsafeByteOperations.unsafeWrap(op.value()))
+            .setLease(0)
+            .setPrevKv(op.prevKV())
+            .build();
+
+    }
+
+    static DeleteRequest toDeleteRequest(DeleteOp<byte[], byte[]> op) {
+        DeleteRequest.Builder reqBuilder = DeleteRequest.newBuilder()
+            .setKey(UnsafeByteOperations.unsafeWrap(op.key()));
+        if (null != op.endKey()) {
+            reqBuilder = reqBuilder.setRangeEnd(
+                UnsafeByteOperations.unsafeWrap(op.endKey()));
+        }
+        return reqBuilder.setPrevKv(op.prevKV()).build();
+    }
+
+    private static List<RequestOp> toRequestOpList(List<Op<byte[], byte[]>> ops) {
+        List<RequestOp> requestOps = Lists.newArrayListWithExpectedSize(ops.size());
+        for (Op<byte[], byte[]> op : ops) {
+            switch (op.type()) {
+                case PUT:
+                    requestOps.add(RequestOp.newBuilder()
+                        .setPutOp(toPutRequest((PutOp<byte[], byte[]>) op))
+                        .build());
+                    break;
+                case DELETE:
+                    requestOps.add(RequestOp.newBuilder()
+                        .setDeleteOp(toDeleteRequest((DeleteOp<byte[], byte[]>) op))
+                        .build());
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown request "
+                        + op.type() + " found in a txn request");
+            }
+        }
+        return requestOps;
+    }
+
+    private static List<Compare> toCompareList(List<CompareOp<byte[], byte[]>> ops) {
+        List<Compare> compares = Lists.newArrayListWithExpectedSize(ops.size());
+        for (CompareOp op : ops) {
+            compares.add(toCompare(op));
+        }
+        return compares;
+    }
+
+    private static Compare toCompare(CompareOp<byte[], byte[]> op) {
+        Compare.Builder compareBuilder = Compare.newBuilder();
+        compareBuilder.setTarget(toProtoCompareTarget(op.getTarget()));
+        compareBuilder.setResult(toProtoCompareResult(op.getResult()));
+        compareBuilder.setKey(UnsafeByteOperations.unsafeWrap(op.getKey()));
+        switch (op.getTarget()) {
+            case MOD:
+                compareBuilder.setModRevision(op.getRevision());
+                break;
+            case CREATE:
+                compareBuilder.setCreateRevision(op.getRevision());
+                break;
+            case VERSION:
+                compareBuilder.setVersion(op.getRevision());
+                break;
+            case VALUE:
+                compareBuilder.setValue(UnsafeByteOperations.unsafeWrap(op.getValue()));
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid compare target " + op.getTarget());
+        }
+        return compareBuilder.build();
+    }
+
+    private static Compare.CompareTarget toProtoCompareTarget(CompareTarget target) {
+        switch (target) {
+            case MOD:
+                return Compare.CompareTarget.MOD;
+            case CREATE:
+                return Compare.CompareTarget.CREATE;
+            case VERSION:
+                return Compare.CompareTarget.VERSION;
+            case VALUE:
+                return Compare.CompareTarget.VALUE;
+            default:
+                throw new IllegalArgumentException("Invalid compare target " + target);
+        }
+    }
+
+    private static Compare.CompareResult toProtoCompareResult(CompareResult result) {
+        switch (result) {
+            case LESS:
+                return Compare.CompareResult.LESS;
+            case EQUAL:
+                return Compare.CompareResult.EQUAL;
+            case GREATER:
+                return Compare.CompareResult.GREATER;
+            case NOT_EQUAL:
+                return Compare.CompareResult.NOT_EQUAL;
+            default:
+                throw new IllegalArgumentException("Invalid compare result " + result);
+        }
+    }
+
+    static TxnRequest toTxnRequest(TxnOp<byte[], byte[]> op) {
+        return TxnRequest.newBuilder()
+            .addAllSuccess(toRequestOpList(op.successOps()))
+            .addAllFailure(toRequestOpList(op.failureOps()))
+            .addAllCompare(toCompareList(op.compareOps()))
+            .build();
+    }
+
+}

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/op/proto/ProtoPutOpImpl.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/op/proto/ProtoPutOpImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.distributedlog.statestore.impl.mvcc.op.proto;
+
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+import lombok.RequiredArgsConstructor;
+import org.apache.distributedlog.common.util.Recycled;
+import org.apache.distributedlog.statestore.api.mvcc.op.OpType;
+import org.apache.distributedlog.statestore.api.mvcc.op.PutOp;
+import org.apache.distributedlog.statestore.proto.Command;
+import org.apache.distributedlog.statestore.proto.PutRequest;
+
+/**
+ * A protobuf encoded put operation.
+ */
+@RequiredArgsConstructor
+public class ProtoPutOpImpl implements PutOp<byte[], byte[]>, Recycled {
+
+    public static ProtoPutOpImpl newPutOp(long revision, Command command) {
+        ProtoPutOpImpl op = RECYCLER.get();
+        op.setCommand(revision, command);
+        return op;
+    }
+
+    private static final Recycler<ProtoPutOpImpl> RECYCLER = new Recycler<ProtoPutOpImpl>() {
+        @Override
+        protected ProtoPutOpImpl newObject(Handle<ProtoPutOpImpl> handle) {
+            return new ProtoPutOpImpl(handle);
+        }
+    };
+
+    private final Handle<ProtoPutOpImpl> recyclerHandle;
+    private PutRequest req;
+    private byte[] key;
+    private byte[] value;
+    private long revision;
+
+    @Override
+    public byte[] value() {
+        if (null != value) {
+            return value;
+        }
+        value = req.getValue().toByteArray();
+        return value;
+    }
+
+    public void setCommand(long revision, Command command) {
+        this.req = command.getPutReq();
+        this.revision = revision;
+    }
+
+    @Override
+    public boolean prevKV() {
+        return req.getPrevKv();
+    }
+
+    @Override
+    public OpType type() {
+        return OpType.PUT;
+    }
+
+    @Override
+    public byte[] key() {
+        if (null != key) {
+            return key;
+        }
+        key = req.getKey().toByteArray();
+        return key;
+    }
+
+    @Override
+    public long revision() {
+        return revision;
+    }
+
+    void reset() {
+        req = null;
+        key = null;
+        value = null;
+        revision = -1L;
+    }
+
+    @Override
+    public void recycle() {
+        reset();
+        recyclerHandle.recycle(this);
+    }
+}

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/op/proto/package-info.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/mvcc/op/proto/package-info.java
@@ -16,32 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.distributedlog.common.coder;
-
-import io.netty.buffer.ByteBuf;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import org.apache.distributedlog.common.util.ByteBufUtils;
-
 /**
- * A byte array {@link Coder}.
+ * Protobuf based op implementations.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ByteArrayCoder implements Coder<byte[]> {
-
-    public static ByteArrayCoder of() {
-        return INSTANCE;
-    }
-
-    private static final ByteArrayCoder INSTANCE = new ByteArrayCoder();
-
-    @Override
-    public byte[] encode(byte[] value) {
-        return value;
-    }
-
-    @Override
-    public byte[] decode(ByteBuf data) {
-        return ByteBufUtils.getArray(data);
-    }
-}
+package org.apache.distributedlog.statestore.impl.mvcc.op.proto;

--- a/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/rocksdb/RocksdbKVStore.java
+++ b/distributedlog-io/statestore/src/main/java/org/apache/distributedlog/statestore/impl/rocksdb/RocksdbKVStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.distributedlog.statestore.impl.rocksdb;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.distributedlog.statestore.impl.rocksdb.RocksConstants.BLOCK_CACHE_SIZE;
 import static org.apache.distributedlog.statestore.impl.rocksdb.RocksConstants.BLOCK_SIZE;
@@ -115,6 +116,9 @@ public class RocksdbKVStore<K, V> implements KVStore<K, V> {
 
     @Override
     public synchronized void init(StateStoreSpec spec) throws StateStoreException {
+        checkArgument(spec.localStateStoreDir().isPresent(),
+            "local state store directory is not configured");
+
         this.name = spec.name();
 
         // initialize the coders
@@ -159,7 +163,7 @@ public class RocksdbKVStore<K, V> implements KVStore<K, V> {
 
         // open the rocksdb
 
-        this.dbDir = spec.localStateStoreDir();
+        this.dbDir = spec.localStateStoreDir().get();
         this.db = openLocalDB(dbDir, opts);
     }
 

--- a/distributedlog-io/statestore/src/main/proto/statestore.proto
+++ b/distributedlog-io/statestore/src/main/proto/statestore.proto
@@ -56,6 +56,8 @@ message ChangeEventMeta {
 
 }
 
+message NopRequest {}
+
 message PutRequest {
     // key is the key, in bytes, to put into the key-value store.
     bytes key = 1;
@@ -138,10 +140,11 @@ message TxnRequest {
     repeated RequestOp failure = 3;
 }
 
-message Request {
+message Command {
     oneof req {
-        PutRequest put_req = 1;
-        DeleteRequest delete_req = 2;
-        TxnRequest txn_req = 3;
+        NopRequest nop_req = 1;
+        PutRequest put_req = 2;
+        DeleteRequest delete_req = 3;
+        TxnRequest txn_req = 4;
     }
 }

--- a/distributedlog-io/statestore/src/main/proto/statestore.proto
+++ b/distributedlog-io/statestore/src/main/proto/statestore.proto
@@ -55,3 +55,93 @@ message ChangeEventMeta {
     KeyMeta kv                  = 2;
 
 }
+
+message PutRequest {
+    // key is the key, in bytes, to put into the key-value store.
+    bytes key = 1;
+    // value is the value, in bytes, to associate with the key in the key-value store.
+    bytes value = 2;
+    // lease is the lease ID to associate with the key in the key-value store. A lease
+    // value of 0 indicates no lease.
+    int64 lease = 3;
+
+    // If prev_kv is set, etcd gets the previous key-value pair before changing it.
+    // The previous key-value pair will be returned in the put response.
+    bool prev_kv = 4;
+}
+
+message DeleteRequest {
+    // key is the first key to delete in the range.
+    bytes key = 1;
+    // range_end is the key following the last key to delete for the range [key, range_end).
+    // If range_end is not given, the range is defined to contain only the key argument.
+    // If range_end is one bit larger than the given key, then the range is all
+    // the all keys with the prefix (the given key).
+    // If range_end is '\0', the range is all keys greater than or equal to the key argument.
+    bytes range_end = 2;
+
+    // If prev_kv is set, gets the previous key-value pairs before deleting it.
+    // The previous key-value pairs will be returned in the delte response.
+    bool prev_kv = 3;
+}
+
+message RequestOp {
+    oneof op {
+        // reserved for range request
+        // RangeRequest range_op = 1;
+        PutRequest put_op = 2; 
+        DeleteRequest delete_op = 3;
+    }
+}
+
+message Compare {
+    enum CompareResult {
+        EQUAL = 0;
+        GREATER = 1;
+        LESS = 2;
+        NOT_EQUAL = 3;
+    }
+    enum CompareTarget {
+        VERSION = 0;
+        CREATE = 1;
+        MOD = 2;
+        VALUE= 3;
+    }
+    // result is logical comparison operation for this comparison.
+    CompareResult result = 1;
+    // target is the key-value field to inspect for the comparison.
+    CompareTarget target = 2;
+    // key is the subject key for the comparison operation.
+    bytes key = 3;
+    oneof target_union {
+        // version is the version of the given key
+        int64 version = 4;
+        // create_revision is the creation revision of the given key
+        int64 create_revision = 5;
+        // mod_revision is the last modified revision of the given key.
+        int64 mod_revision = 6;
+        // value is the value of the given key, in bytes.
+        bytes value = 7;
+    }
+}
+
+message TxnRequest {
+    // compare is a list of predicates representing a conjunction of terms.
+    // If the comparisons succeed, then the success requests will be processed in order,
+    // and the response will contain their respective responses in order.
+    // If the comparisons fail, then the failure requests will be processed in order,
+    // and the response will contain their respective responses in order.
+    repeated Compare compare = 1;
+    // success is a list of requests which will be applied when compare evaluates to true.
+    repeated RequestOp success = 2;
+    // failure is a list of requests which will be applied when compare evaluates to false.
+    repeated RequestOp failure = 3;
+}
+
+message Request {
+    oneof req {
+        PutRequest put_req = 1;
+        DeleteRequest delete_req = 2;
+        TxnRequest txn_req = 3;
+    }
+}

--- a/distributedlog-io/statestore/src/test/java/org/apache/distributedlog/statestore/impl/mvcc/TestMVCCAsyncBytesStoreImpl.java
+++ b/distributedlog-io/statestore/src/test/java/org/apache/distributedlog/statestore/impl/mvcc/TestMVCCAsyncBytesStoreImpl.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.distributedlog.statestore.impl.mvcc;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.distributedlog.DLMTestUtil;
+import org.apache.distributedlog.TestDistributedLogBase;
+import org.apache.distributedlog.api.namespace.Namespace;
+import org.apache.distributedlog.api.namespace.NamespaceBuilder;
+import org.apache.distributedlog.common.coder.ByteArrayCoder;
+import org.apache.distributedlog.common.concurrent.FutureUtils;
+import org.apache.distributedlog.statestore.api.StateStoreSpec;
+import org.apache.distributedlog.statestore.api.mvcc.KVRecord;
+import org.apache.distributedlog.statestore.api.mvcc.op.PutOp;
+import org.apache.distributedlog.statestore.api.mvcc.op.RangeOp;
+import org.apache.distributedlog.statestore.api.mvcc.result.Code;
+import org.apache.distributedlog.statestore.api.mvcc.result.PutResult;
+import org.apache.distributedlog.statestore.api.mvcc.result.RangeResult;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+/**
+ * Unit test of {@link MVCCAsyncBytesStoreImpl}.
+ */
+@Slf4j
+public class TestMVCCAsyncBytesStoreImpl extends TestDistributedLogBase {
+
+    public final TestName runtime = new TestName();
+
+    private static URI uri;
+    private static Namespace namespace;
+
+    @BeforeClass
+    public static void setupCluster() throws Exception {
+        TestDistributedLogBase.setupCluster();
+        uri = DLMTestUtil.createDLMURI(zkPort, "/mvcc");
+        conf.setPeriodicFlushFrequencyMilliSeconds(2);
+        namespace = NamespaceBuilder.newBuilder()
+            .conf(conf)
+            .uri(uri)
+            .clientId("test-mvcc-async-store")
+            .build();
+    }
+
+    @AfterClass
+    public static void teardownCluster() throws Exception {
+        if (null != namespace) {
+            namespace.close();
+        }
+        TestDistributedLogBase.teardownCluster();
+    }
+
+    private String streamName;
+    private File tempDir;
+    private MVCCAsyncBytesStoreImpl store;
+
+    @Before
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        ensureURICreated(uri);
+
+        tempDir = Files.createTempDir();
+
+        store = new MVCCAsyncBytesStoreImpl(
+            () -> new MVCCStoreImpl<>(),
+            () -> namespace);
+    }
+
+    private StateStoreSpec initSpec(String streamName) {
+        return StateStoreSpec.newBuilder()
+            .name(streamName)
+            .keyCoder(ByteArrayCoder.of())
+            .valCoder(ByteArrayCoder.of())
+            .stream(streamName)
+            .localStateStoreDir(tempDir)
+            .build();
+    }
+
+    @After
+    @Override
+    public void teardown() throws Exception {
+        if (null != streamName) {
+            namespace.deleteLog(streamName);
+        }
+
+        if (null != store) {
+            store.close();
+        }
+        if (null != tempDir) {
+            FileUtils.deleteDirectory(tempDir);
+        }
+        super.teardown();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInitMissingStreamName() throws Exception {
+        this.streamName = "test-init-missing-stream-name";
+        StateStoreSpec spec = StateStoreSpec.newBuilder()
+            .name(streamName)
+            .keyCoder(ByteArrayCoder.of())
+            .valCoder(ByteArrayCoder.of())
+            .localStateStoreDir(tempDir)
+            .build();
+        FutureUtils.result(store.init(spec));
+    }
+
+    @Test
+    public void testInit() throws Exception {
+        this.streamName = "test-init";
+        StateStoreSpec spec = initSpec(streamName);
+        FutureUtils.result(store.init(spec));
+        assertTrue(store.ownWriteScheduler());
+        assertFalse(store.ownReadScheduler());
+        assertEquals(streamName, store.name());
+    }
+
+    //
+    // Put & Range Ops
+    //
+
+    private byte[] getKey(int i) {
+        return String.format("key-%05d", i).getBytes(UTF_8);
+    }
+
+    private byte[] getValue(int i) {
+        return String.format("value-%05d", i).getBytes(UTF_8);
+    }
+
+    private List<PutResult<byte[], byte[]>> writeKVs(int numPairs, boolean prevKv) throws Exception {
+        List<CompletableFuture<PutResult<byte[], byte[]>>> results = Lists.newArrayListWithExpectedSize(numPairs);
+        for (int i = 0; i < numPairs; i++) {
+            results.add(writeKV(i, prevKv));
+        }
+        return FutureUtils.result(FutureUtils.collect(results));
+    }
+
+    private CompletableFuture<PutResult<byte[], byte[]>> writeKV(int i, boolean prevKv) {
+        PutOp<byte[], byte[]> op = store.getOpFactory().buildPutOp()
+            .key(getKey(i))
+            .value(getValue(i))
+            .prevKV(prevKv)
+            .build();
+        return store.put(op);
+    }
+
+    @Test
+    public void testPutKvsAndRange() throws Exception {
+        this.streamName = "test-put-kvs";
+        StateStoreSpec spec = initSpec(streamName);
+        FutureUtils.result(store.init(spec));
+        int numPairs = 100;
+        List<PutResult<byte[], byte[]>> kvs = writeKVs(numPairs, true);
+        assertEquals(numPairs, kvs.size());
+
+        for (PutResult<byte[], byte[]> kv : kvs) {
+            assertEquals(Code.OK, kv.code());
+            assertNull(kv.prevKV());
+            kv.recycle();
+        }
+
+        RangeOp<byte[], byte[]> op = store.getOpFactory().buildRangeOp()
+            .key(getKey(20))
+            .endKey(getKey(79))
+            .limit(100)
+            .build();
+        RangeResult<byte[], byte[]> result = FutureUtils.result(store.range(op));
+        assertEquals(Code.OK, result.code());
+        assertEquals(60, result.count());
+        assertEquals(60, result.kvs().size());
+        assertEquals(false, result.hasMore());
+        int idx = 20;
+        for (KVRecord<byte[], byte[]> record : result.kvs()) {
+            assertArrayEquals(getKey(idx), record.key());
+            assertArrayEquals(getValue(idx), record.value());
+            // revision - starts from 1, but the first revision is used for nop barrier record.
+            assertEquals(idx + 2, record.createRevision());
+            assertEquals(idx + 2, record.modifiedRevision());
+            assertEquals(0, record.version());
+            ++idx;
+        }
+        assertEquals(80, idx);
+        result.recycle();
+    }
+
+}

--- a/distributedlog-io/statestore/src/test/java/org/apache/distributedlog/statestore/impl/mvcc/TestMVCCUtils.java
+++ b/distributedlog-io/statestore/src/test/java/org/apache/distributedlog/statestore/impl/mvcc/TestMVCCUtils.java
@@ -16,32 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.distributedlog.common.coder;
+package org.apache.distributedlog.statestore.impl.mvcc;
+
+import static org.apache.distributedlog.statestore.impl.mvcc.MVCCUtils.NOP_CMD;
+import static org.apache.distributedlog.statestore.impl.mvcc.MVCCUtils.newCommand;
+import static org.apache.distributedlog.statestore.impl.mvcc.MVCCUtils.newLogRecordBuf;
+import static org.junit.Assert.assertEquals;
 
 import io.netty.buffer.ByteBuf;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import org.apache.distributedlog.common.util.ByteBufUtils;
+import org.apache.distributedlog.statestore.proto.Command;
+import org.junit.Test;
 
 /**
- * A byte array {@link Coder}.
+ * Test case for {@link MVCCUtils}.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ByteArrayCoder implements Coder<byte[]> {
+public class TestMVCCUtils {
 
-    public static ByteArrayCoder of() {
-        return INSTANCE;
+    @Test
+    public void testNewLogRecordBuf() {
+        Command command = NOP_CMD;
+        ByteBuf buffer = newLogRecordBuf(command);
+        assertEquals(command.getSerializedSize(), buffer.readableBytes());
+        Command another = newCommand(buffer);
+        assertEquals(command, another);
     }
 
-    private static final ByteArrayCoder INSTANCE = new ByteArrayCoder();
-
-    @Override
-    public byte[] encode(byte[] value) {
-        return value;
-    }
-
-    @Override
-    public byte[] decode(ByteBuf data) {
-        return ByteBufUtils.getArray(data);
-    }
 }

--- a/distributedlog-protocol/src/main/java/org/apache/distributedlog/LogRecord.java
+++ b/distributedlog-protocol/src/main/java/org/apache/distributedlog/LogRecord.java
@@ -25,7 +25,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.distributedlog.common.util.ByteBufUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,7 +105,6 @@ import org.slf4j.LoggerFactory;
  *
  * @see LogRecordWithDLSN
  */
-@NotThreadSafe
 public class LogRecord {
 
     private static final Logger LOG = LoggerFactory.getLogger(LogRecord.class);

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <commons-lang3.version>3.3.2</commons-lang3.version>
     <curator.version>4.0.0</curator.version>
     <finagle.version>6.34.0</finagle.version>
-    <freebuilder.version>1.12.3</freebuilder.version>
+    <freebuilder.version>1.14.6</freebuilder.version>
     <guava.version>20.0</guava.version>
     <jetty.version>9.3.11.v20160721</jetty.version>
     <jmh.version>1.19</jmh.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:

- introduce a few settings in storage spec
- add proto definitions for put/delete/txn request
- add ByteArrayCoder
- implement mvcc async store using local rocksdb and distributedlog stream